### PR TITLE
Fix cppcheck warnings

### DIFF
--- a/src/Numbertext.cxx
+++ b/src/Numbertext.cxx
@@ -72,7 +72,7 @@ bool Numbertext::numbertext(std::wstring& number, std::string lang)
     return true;
 }
 
-bool Numbertext::numbertext(std::string& number, std::string lang)
+bool Numbertext::numbertext(std::string& number, const std::string& lang)
 {
     std::wstring wnumber = string2wstring(number);
     bool result = numbertext(wnumber, lang);
@@ -80,7 +80,7 @@ bool Numbertext::numbertext(std::string& number, std::string lang)
     return result;
 }
 
-std::string Numbertext::numbertext(int number, std::string lang)
+std::string Numbertext::numbertext(int number, const std::string& lang)
 {
     std::wstring wnumber = std::to_wstring(number);
     numbertext(wnumber, lang);

--- a/src/Numbertext.hxx
+++ b/src/Numbertext.hxx
@@ -12,12 +12,12 @@ class Numbertext
 {
 public:
     Numbertext();
-    void set_prefix(std::string st) { prefix = st; };
+    void set_prefix(const std::string& st) { prefix = st; };
     bool load(std::string lang, std::string filename = "");
     bool numbertext(std::wstring& number, std::string lang);
     // UTF-8 encoded input
-    bool numbertext(std::string& number, std::string lang);
-    std::string numbertext(int number, std::string lang);
+    bool numbertext(std::string& number, const std::string& lang);
+    std::string numbertext(int number, const std::string& lang);
     static std::wstring string2wstring(const std::string& s);
     static std::string wstring2string(const std::wstring& s);
 


### PR DESCRIPTION
[src/Numbertext.hxx:15]: (performance) Function parameter 'st' should be passed by const reference.
[src/Numbertext.cxx:75]: (performance) Function parameter 'lang' should be passed by const reference.
[src/Numbertext.cxx:83]: (performance) Function parameter 'lang' should be passed by const reference.