### PR TITLE
add -encoding utf8 to javac call

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -1,6 +1,6 @@
 all:
 	cp ../data/*.sor org/numbertext/data
-	CLASSPATH=. javac org/numbertext/Numbertext.java
+	CLASSPATH=. javac -encoding utf8 org/numbertext/Numbertext.java
 	jar cfm numbertext.jar Manifest.txt org
 	java -jar numbertext.jar
 


### PR DESCRIPTION
Hi Laszlo,

seems like javac doesn't like your name in a clean chroot without any locale set (C).

See
https://buildd.debian.org/status/fetch.php?pkg=libnumbertext&arch=arm64&ver=1.0~beta2-2&stamp=1526164029&raw=0:

```
CLASSPATH=. javac -source 1.8 -target 1.8 org/numbertext/Numbertext.java
warning: [options] bootstrap class path not set in conjunction with -source 8
org/numbertext/Numbertext.java:2: error: unmappable character (0xC3) for encoding US-ASCII
 * 2009-2010 (c) L??szl?? N??meth
                  ^
org/numbertext/Numbertext.java:2: error: unmappable character (0xA1) for encoding US-ASCII
 * 2009-2010 (c) L??szl?? N??meth
                   ^
org/numbertext/Numbertext.java:2: error: unmappable character (0xC3) for encoding US-ASCII
 * 2009-2010 (c) L??szl?? N??meth
                       ^
org/numbertext/Numbertext.java:2: error: unmappable character (0xB3) for encoding US-ASCII
 * 2009-2010 (c) L??szl?? N??meth
                        ^
org/numbertext/Numbertext.java:2: error: unmappable character (0xC3) for encoding US-ASCII
 * 2009-2010 (c) L??szl?? N??meth
                           ^
org/numbertext/Numbertext.java:2: error: unmappable character (0xA9) for encoding US-ASCII
 * 2009-2010 (c) L??szl?? N??meth
                            ^
6 errors
1 warning
Makefile:2: recipe for target 'all' failed
```

so we should probably add a `encoding -utf8` to the javac call. Did so in Debians 1.0~beta2-3.

Regards,

Rene