### PR TITLE
Performance: avoid unnecessary value parameters

### DIFF
--- a/src/Numbertext.cxx
+++ b/src/Numbertext.cxx
@@ -19,7 +19,7 @@
 #define MODULE_DIR ""
 #define SOROS_EXT ".sor"
 
-bool readfile(std::string filename, std::wstring& result)
+bool readfile(const std::string& filename, std::wstring& result)
 {
     std::wifstream wif(filename);
     if (wif.fail())
@@ -59,7 +59,7 @@ bool Numbertext::load(std::string lang, std::string filename)
     return true;
 }
 
-bool Numbertext::numbertext(std::wstring& number, std::string lang)
+bool Numbertext::numbertext(std::wstring& number, const std::string& lang)
 {
     auto module = modules.find(lang);
     if (module == modules.end())

--- a/src/Numbertext.hxx
+++ b/src/Numbertext.hxx
@@ -14,7 +14,7 @@ public:
     Numbertext();
     void set_prefix(const std::string& st) { prefix = st; };
     bool load(std::string lang, std::string filename = "");
-    bool numbertext(std::wstring& number, std::string lang);
+    bool numbertext(std::wstring& number, const std::string& lang);
     // UTF-8 encoded input
     bool numbertext(std::string& number, const std::string& lang);
     std::string numbertext(int number, const std::string& lang);

--- a/src/Soros.cxx
+++ b/src/Soros.cxx
@@ -200,8 +200,8 @@ void Soros::run(std::wstring& input, int& level, bool begin, bool end)
 std::wstring Soros::translate(
         std::wstring s,
         const std::wstring chars,
-        const std::wstring chars2,
-        const std::wstring delim)
+        const std::wstring& chars2,
+        const std::wstring& delim)
 {
     int i = 0;
     for(const wchar_t& ch : chars)

--- a/src/Soros.hxx
+++ b/src/Soros.hxx
@@ -23,7 +23,7 @@ public:
     Soros(std::wstring program, std::wstring filtered_lang);
     int run(std::wstring& input);
     static std::wstring translate(std::wstring s,
-                std::wstring chars, std::wstring chars2, std::wstring delim);
+                std::wstring chars, const std::wstring& chars2, const std::wstring& delim);
 private:
     void run(std::wstring& input, int& level, bool begin = true, bool end = true);
     static void replace(std::wstring& s, const std::wstring& search,


### PR DESCRIPTION
These parameters are copied for each invocation but only used as a const
reference. Make them const references instead for a small performance
improvement.