### PR TITLE
Refactor: readability fixes

### DIFF
--- a/src/Numbertext.cxx
+++ b/src/Numbertext.cxx
@@ -87,24 +87,24 @@ std::string Numbertext::numbertext(int number, const std::string& lang)
     return wstring2string(wnumber);
 }
 
-std::wstring Numbertext::string2wstring(const std::string& st)
+std::wstring Numbertext::string2wstring(const std::string& s)
 {
 #ifndef NUMBERTEXT_BOOST
     typedef std::codecvt_utf8<wchar_t> convert_type;
     std::wstring_convert<convert_type, wchar_t> converter;
-    return converter.from_bytes( st );
+    return converter.from_bytes( s );
 #else
-    return ::locale::conv::utf_to_utf<wchar_t>(st.c_str(), st.c_str() + st.size());
+    return ::locale::conv::utf_to_utf<wchar_t>(s.c_str(), s.c_str() + s.size());
 #endif
 }
 
-std::string Numbertext::wstring2string(const std::wstring& st)
+std::string Numbertext::wstring2string(const std::wstring& s)
 {
 #ifndef NUMBERTEXT_BOOST
     typedef std::codecvt_utf8<wchar_t> convert_type;
     std::wstring_convert<convert_type, wchar_t> converter;
-    return converter.to_bytes( st );
+    return converter.to_bytes( s );
 #else
-    return ::locale::conv::utf_to_utf<char>(st.c_str(), st.c_str() + st.size());
+    return ::locale::conv::utf_to_utf<char>(s.c_str(), s.c_str() + s.size());
 #endif
 }

--- a/src/Soros.cxx
+++ b/src/Soros.cxx
@@ -33,28 +33,28 @@ const wregex Soros::func ( Soros::translate (
     Soros::m2.substr(0, 4), Soros::c, L"\\"));  // \$, \(, \), \| -> \uE000..\uE003
 
 void Soros::replace(std::wstring& s, const std::wstring& search,
-                          const std::wstring& str) {
+                          const std::wstring& replace) {
     size_t pos = 0;
     while ((pos = s.find(search, pos)) != std::wstring::npos) {
-         s.replace(pos, search.length(), str);
-         pos += str.length();
+         s.replace(pos, search.length(), replace);
+         pos += replace.length();
     }
 }
 
-Soros::Soros(std::wstring source, std::wstring filtered_lang):
+Soros::Soros(std::wstring program, std::wstring filtered_lang):
     begins(0),
     ends(0)
 {
-    source = translate(source, m, c, L"\\");     // \\, \", \;, \# -> \uE000..\uE003
+    program = translate(program, m, c, L"\\");     // \\, \", \;, \# -> \uE000..\uE003
     // switch off all country-dependent lines, and switch on the requested ones
-    source = regex_replace(source, wregex(L"(^|[\n;])([^\n;#]*#[^\n]*\\[:[^\n:\\]]*:\\][^\n]*)"), L"$1#$2");
+    program = regex_replace(program, wregex(L"(^|[\n;])([^\n;#]*#[^\n]*\\[:[^\n:\\]]*:\\][^\n]*)"), L"$1#$2");
     replace(filtered_lang, L"_", L"-");
-    source = regex_replace(source, wregex(L"(^|[\n;])#([^\n;#]*#[^\n]*\\[:" + filtered_lang + L":\\][^\n]*)"), L"$1$2");
-    source = regex_replace(source, wregex(L"(#[^\n]*)?(\n|$)"), L";"); // remove comments
+    program = regex_replace(program, wregex(L"(^|[\n;])#([^\n;#]*#[^\n]*\\[:" + filtered_lang + L":\\][^\n]*)"), L"$1$2");
+    program = regex_replace(program, wregex(L"(#[^\n]*)?(\n|$)"), L";"); // remove comments
     // __numbertext__ sets the place of left zero deletion rule
-    if (source.find(L"__numbertext__") == std::wstring::npos)
-        source.insert(0, L"__numbertext__;");
-    source = regex_replace(source, wregex(L"__numbertext__"),
+    if (program.find(L"__numbertext__") == std::wstring::npos)
+        program.insert(0, L"__numbertext__;");
+    program = regex_replace(program, wregex(L"__numbertext__"),
                         // default left zero deletion
                         L"\"([a-z][-a-z]* )?0+(0|[1-9]" FIX L"\\d*)\" $$(" FIX L"\\1" FIX L"\\2);"
                         // separator function
@@ -69,9 +69,9 @@ Soros::Soros(std::wstring source, std::wstring filtered_lang):
     wregex quoteStart(L"^\"");
     wregex quoteEnd(L"\"$");
     std::wstring smacro;
-    while ((pos = source.find(L";", pos)) != std::wstring::npos) {
+    while ((pos = program.find(L";", pos)) != std::wstring::npos) {
         wsmatch sp;
-        std::wstring linOrig = source.substr(old_pos, pos - old_pos);
+        std::wstring linOrig = program.substr(old_pos, pos - old_pos);
         // pattern extension after == macro ==:
         // foo bar -> "macro foo" bar
         // "foo bar" baz -> "macro foo bar" baz

--- a/src/Soros.cxx
+++ b/src/Soros.cxx
@@ -68,7 +68,7 @@ Soros::Soros(std::wstring source, std::wstring filtered_lang):
     size_t old_pos = 0;
     wregex quoteStart(L"^\"");
     wregex quoteEnd(L"\"$");
-    std::wstring smacro = L"";
+    std::wstring smacro;
     while ((pos = source.find(L";", pos)) != std::wstring::npos) {
         wsmatch sp;
         std::wstring linOrig = source.substr(old_pos, pos - old_pos);
@@ -110,7 +110,7 @@ Soros::Soros(std::wstring source, std::wstring filtered_lang):
                 std::wcout << L"Soros: bad regex in \"" << sp[1].str() << "\"" << std::endl;
                 break;
             }
-            std::wstring s2 = L"";
+            std::wstring s2;
             if (sp.size() > 1)
             {
                 s2 = regex_replace(sp[2].str(), quoteStart, L"");

--- a/src/spellout.cxx
+++ b/src/spellout.cxx
@@ -47,7 +47,7 @@ int main(int argc, char* argv[])
 
     Numbertext nt;
     State state = State::base;
-    std::string prefix = "";
+    std::string prefix;
     for (int i = 1; i < argc; i++)
     {
         if (state == State::flag_lang || state == State::flag_prefix)


### PR DESCRIPTION
1) No need to set a new string to empty, that's the default.

2) Fix cases where the interface and the implementation had different parameter names (adjust implementation, `replace` is superior to `str`, etc.)