### PR TITLE
Add travis ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: cpp
+script:
+    - autoreconf -i
+    - CC=gcc-7 CXX=g++-7 ./configure
+    - make
+    - make -f Makefile.orig check
+addons:
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+        packages:
+            - g++-7


### PR DESCRIPTION
This is just the travis markup to get things going. If you like the idea of having CI for libnumbertext, then here is how you can turn it on after merging this pull request:

https://docs.travis-ci.com/user/getting-started