### PR TITLE
[eo] Adjectival suffix for abbreviated ordinals

### DIFF
--- a/data/eo.sor
+++ b/data/eo.sor
@@ -65,7 +65,7 @@ USD:(\D+) $(\1: usona dolaro, usonaj dolaroj, cendo, cendoj)
 
 == ordinal-number ==
 
-(\d+)	\1.
+(\d+)	\1-a
 
 == help ==
 


### PR DESCRIPTION
In Esperanto, ordinal numbers are formed from cardinals by adding the _-a_ suffix to them: _unu → unua_. This suffix is also applied to the abbreviated form, but connected with a hyphen, as it is usually done for abbreviations formed through removal of middle letters (e.g., _doktoro → D-ro_): _19-a jarcento_.