### PR TITLE
README: minimalist conversion to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-Soros interpreters for C++11, Java, JavaScript and Python
+# Soros interpreters for C++11, Java, JavaScript and Python
 
+[![Build Status](https://travis-ci.org/Numbertext/libnumbertext.png?branch=master)](https://travis-ci.org/Numbertext/libnumbertext)
+
+```
 Language-neutral NUMBERTEXT and MONEYTEXT functions for LibreOffice Calc
 
 version 1.0 (2018-07-28)
@@ -172,3 +175,4 @@ make -f Makefile.orig check
 test/thaicheck.ods is a simple test of the equivalence of
 the Soros implementation of Thai number to number name conversion
 and BAHTTEXT function.
+```


### PR DESCRIPTION
Just convert the title and add travis status image; keep the rest as-is
inside a code block.

See the rendering result here: https://github.com/vmiklos/libnumbertext/tree/travis-doc