### PR TITLE
fix DEFPATH in spellout

### DIFF
--- a/src/spellout.cxx
+++ b/src/spellout.cxx
@@ -10,7 +10,7 @@
 
 #define LANG "LANG"
 #define PATH "NUMBERTEXTPATH"
-#define DEFPATH "/usr/share/numbertext/"
+#define DEFPATH "/usr/share/libnumbertext/"
 #define DEFPATH2 "data/"
 
 enum State { base, loaded, flag_lang, flag_prefix};


### PR DESCRIPTION
Hi,

see http://bugs.debian.org/908237

make install installs them (and libnumbertext.pc says, too) it into
/usr/lib/libnumbertext

Regards,

Rene