### PR TITLE
replaced the system line seperator with a fixed value.

### DIFF
--- a/java/org/numbertext/Numbertext.java
+++ b/java/org/numbertext/Numbertext.java
@@ -23,7 +23,7 @@ public class Numbertext {
         String line = null;
         while (( line = f.readLine()) != null) {
             st.append(line);
-            st.append(System.getProperty("line.separator"));
+            st.append("\n");
         }
         s = new Soros(new String(st), langcode);
         if (modules != null && langfile != null) modules.put(langcode, s);


### PR DESCRIPTION
Getting the line seperator does not work for windows machines since it has a different EOL. using the line separator that the lib checks on makes sure it also works on windows machines. 