### PR TITLE
Don't depend on en_US.UTF-8 locale

### DIFF
--- a/src/Numbertext.cxx
+++ b/src/Numbertext.cxx
@@ -2,6 +2,8 @@
  * 2018 (c) László Németh
  * License: LGPL/BSD dual license */
 
+#include <codecvt>
+#include <locale>
 #include <sstream>
 #include <fstream>
 
@@ -11,8 +13,6 @@
   #include <boost/locale/encoding_utf.hpp>
   using namespace boost;
 #else
-  #include <codecvt>
-  #include <locale>
   using namespace std;
 #endif
 
@@ -25,11 +25,7 @@ bool readfile(const std::string& filename, std::wstring& result)
     std::wifstream wif(filename);
     if (wif.fail())
         return false;
-#ifdef _MSC_VER
     wif.imbue(std::locale(std::locale(), new std::codecvt_utf8<wchar_t>));
-#else
-    wif.imbue(std::locale("en_US.UTF-8"));
-#endif
     std::wstringstream wss;
     wss << wif.rdbuf();
     result = wss.str();


### PR DESCRIPTION
Instead, create locale with codecvt_utf8 facet on all platforms (even if
codecvt_utf8 is deprecated since C++17).  There is no guarantee that
"en_US.UTF-8" is a supported locale name, so the locale constructor might throw
a runtime_error.  (See the discussion in the comments to
<https://gerrit.libreoffice.org/#/c/62508/> "Add check for en_US.utf8 locale"
for a real-live example of issues caused by that.)

(And the <codecvt> and <locale> headers apparently need to be included always,
regardless of NUMBERTEXT_BOOST.)