### PR TITLE
Fix inconsistency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ nl	Dutch
 nn	Norwegian Nynorsk
 no	Norwegian (Bokmål)
 pl	Polish
-pt	Brazilian Portuguese
-pt-PT	Portuguese
+pt	Portuguese
+pt-BR	Brazilian Portuguese
 ro	Romanian
 ru	Russian
 sh	Serbian (Latin)


### PR DESCRIPTION
In the pt.sor file the conditionals are set for "pt-BR" language code,
so it seems that by default the European Portuguese version is used,
and for Brazilian one "pt-BR" should be explicitly specified.