### PR TITLE
Fix Czech cardinals and add ordinals for genders

### DIFF
--- a/data/cs.sor
+++ b/data/cs.sor
@@ -1,8 +1,7 @@
 ^0 nula
-^1$ jedno
-1 jeden
-^2$ dvě
+1 jedna
 2 dva
+^2$ dvě
 3 tři
 4 čtyři
 5 pět
@@ -27,7 +26,7 @@
 (\d)(\d\d) $1 set[ $2]
 1(\d\d\d) tisíc[ $1]
 ([234])(\d\d\d) $1 tisíce[ $2]
-(\d{1,3})(\d\d\d) $1 tisíce[ $2]
+(\d{1,3})(\d\d\d) $1 tisíc[ $2]
 1(\d{6}) milión[ $1]
 ([234])(\d{6}) $1 milióny[ $2]
 (\d{1,3})(\d{6}) $1 miliónů[ $2]
@@ -92,17 +91,19 @@ USD:(\D+) $(\1: americký dolar, amerických dolarů, cent, centů)
 
 == cardinal-neuter ==
 
+1 jedno
+2 dvě
 (.*) $1
 
 == cardinal-feminine ==
 
 1 jedna
+2 dvě
 (.*) $1
 
 == cardinal-masculine ==
 
 1 jeden
-2 dva
 (.*) $1
 
 == ordinal ==
@@ -116,7 +117,7 @@ USD:(\D+) $(\1: americký dolar, amerických dolarů, cent, centů)
 "(.*)devět set(.*)"	$(ordinal \1devítistý\2)
 
 nula	nultý
-(.*)(jedno|jeden)	$(ordinal \1první)
+(.*)(jedno|jedna|jeden)	$(ordinal \1první)
 (.*)(jedenáct)	$(ordinal \1jedenáctý)
 (.*)(dva|dvě)	$(ordinal \1druhý)
 (.*)(dvě|dva)\b(.*)	$(ordinal \1druhý\3)

--- a/data/cs.sor
+++ b/data/cs.sor
@@ -128,7 +128,7 @@ nula	nultý
 "(.*)(c|s)et\b(.*)"	$(ordinal \1\2átý\3)
 (.*)sto\b(.*)		$(ordinal \1stý\2)
 (.*)tisíce?(.*)		\1tisící\2
-(.*)milión[yů](.*)	\1milióntý\2
+(.*)milión[yů]?(.*)	\1milióntý\2
 (.*)miliard[ay]?(.*)	\1miliardtý\2
 (.*)			\1
 

--- a/data/cs.sor
+++ b/data/cs.sor
@@ -133,11 +133,27 @@ nula	nultý
 (.*)miliard[ay]?(.*)	\1miliardtý\2
 (.*)			\1
 
+== ordinal-masculine ==
+
+(.*) $(ordinal |$1)
+
+== ordinal-feminine ==
+
+([-−]?\d+) $(ordinal-feminine |$(ordinal-masculine \1))
+(.*)ý(.*)		$(ordinal-feminine \1á\2)
+(.*)	\1
+
+== ordinal-neuter ==
+
+([-−]?\d+) $(ordinal-neuter |$(ordinal-masculine \1))
+(.*)ý(.*)		$(ordinal-neuter \1é\2)
+(.*)	\1
+
 == ordinal-number ==
 
 (\d+)	\1.
 
 == help ==
 
-"" |$(1)|, |$(2)|, |$(3)|\n$(help cardinal-neuter)$(help cardinal-feminine)$(help cardinal-masculine)$(help ordinal)$(help ordinal-number)
+"" |$(1)|, |$(2)|, |$(3)|\n$(help cardinal-neuter)$(help cardinal-feminine)$(help cardinal-masculine)$(help ordinal)$(help ordinal-masculine)$(help ordinal-feminine)$(help ordinal-neuter)$(help ordinal-number)
 (.*) \1: |$(\1 1)|, |$(\1 2)|, |$(\1 3)|\n

--- a/data/cs.sor
+++ b/data/cs.sor
@@ -62,32 +62,42 @@
 
 # currency
 
-# unit/subunit singular/plural
+# unit/subunit singular / plural / plural genitiv
 
-us:([^,]*),([^,]*),([^,]*),([^,]*) \1
-up:([^,]*),([^,]*),([^,]*),([^,]*) \2
-ss:([^,]*),([^,]*),([^,]*),([^,]*) \3
-sp:([^,]*),([^,]*),([^,]*),([^,]*) \4
+us:([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*) \1
+up:([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*) \2
+ug:([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*) \3
+ss:([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*) \4
+sp:([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*) \5
+sg:([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*) \6
+ugender:([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*) \7
+sgender:([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*) \8
 
-CHF:(\D+) $(\1: švýcarský frank, švýcarských franků, centim, centimů)
-CNY:(\D+) $(\1: juan renminbi, juan renminbi, fen, fen)
-CZK:(\D+) $(\1: koruna česká, korun českých, haléř, haléřů)
-EUR:(\D+) $(\1: euro, euro, cent, centů)
-GBP:(\D+) $(\1: libra šterlinků, libra šterlinků, penny, pence)
-JPY:(\D+) $(\1: jen, jenů, sen, sen)
-USD:(\D+) $(\1: americký dolar, amerických dolarů, cent, centů)
+CHF:(\D+) $(\1: švýcarský frank, švýcarské franky, švýcarských franků, centim, centimy, centimů,masculine,masculine)
+CNY:(\D+) $(\1: jüan, jüany, jüanů, fen, feny, fenů,masculine,masculine)
+CZK:(\D+) $(\1: koruna česká, koruny české, korun českých, haléř, haléře, haléřů,feminine,masculine)
+EUR:(\D+) $(\1: euro, eura, eur, cent, centy, centů,neuter,masculine)
+GBP:(\D+) $(\1: libra šterlinků, libry šterlinků, liber šterlinků, pence, pence, pencí,feminine,feminine)
+JPY:(\D+) $(\1: jen, jeny, jenů, sen, seny, senů,masculine,masculine)
+RUB:(\D+) $(\1: rubl, rubly, rublů, kopějka, kopějky, kopějek,masculine,feminine)
+SKK:(\D+) $(\1: slovenská koruna, slovenské koruny, slovenských korun, haléř, haléře, haléřů,feminine,masculine)
+USD:(\D+) $(\1: americký dolar, americké dolary, amerických dolarů, cent, centy, centů,masculine,masculine)
 
-"([A-Z]{3}) ([-−]?1)([.,]00?)?" $2$(\1:us)
-"([A-Z]{3}) ([-−]?\d+)([.,]00?)?" $2$(\1:up)
+"([A-Z]{3}) ([-−]?1)([.,]00?)?" $(cardinal-$(\1:ugender) \2)$(\1:us)
+"([A-Z]{3}) ([-−]?[2-4])([.,]00?)?" $(cardinal-$(\1:ugender) \2)$(\1:up)
+"([A-Z]{3}) ([-−]?\d+)([.,]00?)?" $(cardinal-$(\1:ugender) \2)$(\1:ug)
 
-"(CNY [-−]?\d+)[.,]10?" $1 $2 jiao
-"(CNY [-−]?\d+)[.,](\d)0?" $1 $2 jiao
-"(CNY [-−]?\d+[.,]\d)1" $1 $2 fen
-"(CNY [-−]?\d+[.,]\d)(\d)" $1 $2 fen
+"(CNY [-−]?\d+)[.,]10?" $1 $(cardinal-neuter 1) ťiao
+"(CNY [-−]?\d+)[.,](\d)0?" $1 $(cardinal-neuter \2) ťiao
+"((CNY) [-−]?\d+[.,]\d)1" $1 $(cardinal-masculine 1)$(\2:ss)
+"((CNY) [-−]?\d+[.,]\d)(2|3|4)" $1 $(cardinal-masculine \3)$(\2:sp)
+"((CNY) [-−]?\d+[.,]\d)(\d)" $1 $(cardinal-masculine \3)$(\2:sg)
 
-"(([A-Z]{3}) [-−]?\d+)[.,](01)" $1 $(1)$(\2:ss)
-"(([A-Z]{3}) [-−]?\d+)[.,](\d)" $1 $(\30)$(\2:sp)
-"(([A-Z]{3}) [-−]?\d+)[.,](\d\d)" $1 $3$(\2:sp)
+"(([A-Z]{3}) [-−]?\d+)[.,](00)" $1 $(cardinal-$(\2:sgender) \1)$(\2:sg)
+"(([A-Z]{3}) [-−]?\d+)[.,](01)" $1 $(cardinal-$(\2:sgender) \3)$(\2:ss)
+"(([A-Z]{3}) [-−]?\d+)[.,](02|03|04)" $1 $(cardinal-$(\2:sgender) \3)$(\2:sp)
+"(([A-Z]{3}) [-−]?\d+)[.,](\d\d)" $1 $(cardinal-$(\2:sgender) \3)$(\2:sg)
+"(([A-Z]{3}) [-−]?\d+)[.,](\d)" $1 $(cardinal-$(\2:sgender) \30)$(\2:sg)
 
 == cardinal-neuter ==
 


### PR DESCRIPTION
This fixes some Czech cardinals and adds ordinals for all three Czech genders.

@zcrhonek, @TomKladno - Please review the changes.

There are still wrong ordinals in combinations involving big numbers, e.g. `1001001` should be `milióntý tisící první` but the output is `milión tisící první`. I believe the rest of the ordinals should be recursive as well, e.g. 
```
(.*)milión[yů]?(.*)	$(ordinal \1milióntý\2)
```
however in that case I get "too much recursion" JavaScript error when trying it in the web interface (https://numbertext.github.io/Soros.html). Is this supposed to work, or am I doing something wrong?