### PR TITLE
[IMP] Small adjustments for pt_BR

### DIFF
--- a/data/pt.sor
+++ b/data/pt.sor
@@ -42,7 +42,7 @@
 :0*\d00(\d{6}){0,} " e "	# mil e quinhentos
 :0*\d{1,2}000(\d{6}){0,} " e "	# um milhão e onze mil
 :0*\d{1}00000(\d{6}){0,} " e "	# um milhão e cem mil
-:\d+ " "
+:\d+ ", "  # cento e vinte e três milhões, quatrocentos e cinquenta e seis mil, setecentos e oitenta e nove
 
 pl:1	ão			# milhão
 pl:.*	ões			# milhões
@@ -138,6 +138,7 @@ f:(.*),(.*) \1\2
 
 == ordinal(-masculine)? ==
 
+0 zerésimo
 1 primeiro
 2 segundo
 3 terceiro
@@ -183,8 +184,9 @@ f:(.*),(.*) \1\2
 == (ordinal)-number(-feminine|-masculine)? ==
 
 ([-−]?\d+) \3$(ordinal-number $(\1\2 \3))
-.*er .ᵉʳ
+.*a ª    # [:pt-BR:]
 .*a .ª
+.*o º    # [:pt-BR:]
 .*o .º
 
 == help ==


### PR DESCRIPTION
Line #45 - Using comma to separate groups:
    spellout -l pt-BR 123456789
    before: cento e vinte e três milhões quatrocentos e cinquenta e seis mil setecentos e oitenta e nove
    after: cento e vinte e três milhões, quatrocentos e cinquenta e seis mil, setecentos e oitenta e nove

Line #141 - Adding ordinal zero
    spellout -l pt-BR -p ordinal 0
    before: 
    after: zerésimo

Deleted line #187 - Portuguese doesn't use "primer" like Spanish

Lines #187 and #189 - Brazil doesn't add the dot before de ª and º symbols
    spellout -l pt-BR -p ordinal-number 10
    before: 10.º
    after: 10º