### PR TITLE
Fix and extend Czech decimals

### DIFF
--- a/data/cs.sor
+++ b/data/cs.sor
@@ -39,7 +39,7 @@
 1(\d{15}) biliarda[ $1]
 ([234])(\d{15}) $1 biliardy[ $2]
 (\d{1,3})(\d{15}) $1 biliard[ $2]
-1(\d{18}) trilion[ $1]
+1(\d{18}) trilión[ $1]
 ([234])(\d{18}) $1 trilióny[ $2]
 (\d{1,3})(\d{18}) $1 triliónů[ $2]
 1(\d{21}) triliarda[ $1]

--- a/data/cs.sor
+++ b/data/cs.sor
@@ -55,10 +55,10 @@
 
 # decimals
 
-([-−]?\d+)[.,] $1| čárka
-([-−]?\d+[.,])([^0]\d) $1| |$2
-([-−]?\d+[.,])(\d)(\d)(\d) $1| |$2 |$3 |$4
-([-−]?\d+[.,]\d*)(\d) $1| |$2
+([-−]?(0|1))[.,] $1| celá
+([-−]?(2|3|4))[.,] $(cardinal-feminine \1)| celé
+([-−]?\d+)[.,] $1| celých
+([-−]?\d+[.,])(\d{1,26}) $1| |$(cardinal-feminine \2) $(fraction .\2)
 
 # currency
 
@@ -98,6 +98,39 @@ USD:(\D+) $(\1: americký dolar, americké dolary, amerických dolarů, cent, ce
 "(([A-Z]{3}) [-−]?\d+)[.,](02|03|04)" $1 $(cardinal-$(\2:sgender) \3)$(\2:sp)
 "(([A-Z]{3}) [-−]?\d+)[.,](\d\d)" $1 $(cardinal-$(\2:sgender) \3)$(\2:sg)
 "(([A-Z]{3}) [-−]?\d+)[.,](\d)" $1 $(cardinal-$(\2:sgender) \30)$(\2:sg)
+
+== fraction ==
+
+.(\d{1}) desetin$(fraction-suffix \1)
+.(\d{2}) setin$(fraction-suffix \1)
+.(\d{3}) tisícin$(fraction-suffix \1)
+.(\d{4}) desetitisícin$(fraction-suffix \1)
+.(\d{5}) stotisícin$(fraction-suffix \1)
+.(\d{6}) milióntin$(fraction-suffix \1)
+.(\d{7}) desetimilióntin$(fraction-suffix \1)
+.(\d{8}) stomilióntin$(fraction-suffix \1)
+.(\d{9}) miliardtin$(fraction-suffix \1)
+.(\d{10}) desetimiliardtin$(fraction-suffix \1)
+.(\d{11}) stomiliardtin$(fraction-suffix \1)
+.(\d{12}) bilióntina$(fraction-suffix \1)
+.(\d{13}) desetibilióntin$(fraction-suffix \1)
+.(\d{14}) stobilióntin$(fraction-suffix \1)
+.(\d{15}) biliardtin$(fraction-suffix \1)
+.(\d{16}) desetibiliardtin$(fraction-suffix \1)
+.(\d{17}) stobiliardtin$(fraction-suffix \1)
+.(\d{18}) trilióntin$(fraction-suffix \1)
+.(\d{19}) desetitrilióntin$(fraction-suffix \1)
+.(\d{20}) stotrilióntin$(fraction-suffix \1)
+.(\d{21}) triliardtin$(fraction-suffix \1)
+.(\d{22}) desetitriliardtin$(fraction-suffix \1)
+.(\d{23}) stotriliardtin$(fraction-suffix \1)
+.(\d{24}) kvadrilióntin$(fraction-suffix \1)
+.(\d{25}) desetikvadrilióntin$(fraction-suffix \1)
+.(\d{26}) stokvadrilióntin$(fraction-suffix \1)
+.
+== fraction-suffix ==
+(0*)1 a
+(0*)(2|3|4) y
 
 == cardinal-neuter ==
 

--- a/data/cs.sor
+++ b/data/cs.sor
@@ -171,9 +171,9 @@ nula	nultý
 (.*)devět\b(.*)		$(ordinal \1devátý\2)
 "(.*)(c|s)et\b(.*)"	$(ordinal \1\2átý\3)
 (.*)sto\b(.*)		$(ordinal \1stý\2)
-(.*)tisíce?(.*)		\1tisící\2
-(.*)milión[yů]?(.*)	\1milióntý\2
-(.*)miliard[ay]?(.*)	\1miliardtý\2
+(.*)tisíce?(.*)		$(ordinal \1)tisící$(ordinal \2)
+(.*)milión[yů]?(.*)	$(ordinal \1)milióntý$(ordinal \2)
+(.*)miliard[ay]?(.*)	$(ordinal \1)miliardtý$(ordinal \2)
 (.*)			\1
 
 == ordinal-masculine ==


### PR DESCRIPTION
This adds support for Czech decimals.

Apart from that, a spelling and ordinals fix (spotted in #98) is included.

@zcrhonek @TomKladno As usually, I will appreciate if you have a look at the changes.