### PR TITLE
data for Walloon language

### DIFF
--- a/data/wa.sor
+++ b/data/wa.sor
@@ -1,0 +1,116 @@
+# data for Walloon language (in "rifondou walon" spelling)
+^0 zero
+1 onk
+2 deus
+3 troes
+4 cwate
+5 cénk
+6 shijh
+7 set
+8 ût
+9 nouv
+10 dijh
+11 onze
+12 doze
+13 traze
+14 catoize
+15 cwénze
+16 saze
+20 vint
+30 trinte
+40 cwarante
+50 céncwante
+60 swessante
+70 septante
+
+81 cwatru-vint-ey-onk		# [:wa-Nam:]
+8(\d) cwatru-vint[-$1]		# [:wa-Nam:]
+81 ûtante-ey-onk		# default
+8(\d) ûtante[-$1]       	# default
+
+90 nonante
+
+(\d)1 $(\10)-ey-onk
+(\d)(\d) $(\10)-$2
+
+1(\d\d) cint[ $1]
+(\d)00$ $1 cints
+(\d)(\d\d) $1 cint[ $2]
+1(\d{3}) meye[ $1]
+(\d{1,3})(\d{3}) $1 meye[ $2]
+1(\d{6}) on miyon[-$1]
+(\d{1,3})(\d{6}) $1| miyons[ $2]
+1(\d{9}) on miyård[ $1]
+(\d{1,3})(\d{9}) $1| miyårds[ $2]
+1(\d{12}) on biyon[ $1]
+(\d{1,3})(\d{12}) $1| biyons[ $2]
+1(\d{18}) on triyon[ $1]
+(\d{1,3})(\d{18}) $1| triyons[ $2]
+1(\d{24}) on cwadriyon[-$1]
+(\d{1,3})(\d{24}) $1| cwadriyons[ $2]
+
+# negative number
+
+[-−](\d+) moens |$1
+
+# decimals
+
+"([-−]?\d+)[.,]" "$1|, coma"
+
+# digits are said by groups of two (first is single if the number of digits is odd).
+# leading zeros must be said too.
+"([-−]?\d+[.,]\d*)00" $1|, zero zero
+"([-−]?\d+[.,]\d*)0(\d)" $1|, zero $2
+"([-−]?\d+[.,]\d*)(\d\d)" $1|, |$2
+"([-−]?\d+[.,]\d*)(\d)" $1|, |$2
+
+== feminine ==
+
+1 ene
+(.*)    $1
+
+== masculine ==
+
+(.*)    $1
+
+== ordinal(-masculine)? ==
+
+1		prumî
+
+([-−]?\d+)	$(ordinal |$2)
+
+(.*o)  	        \2yinme	# zeroyinme
+(.*on)k		\2inme	# -ey-oninme
+(.*(eu|oe))s	\2jhinme # deujhinme, troejhinme
+(.*wat)e	\2rinme	# cwatrinme
+(.*)[es]	\2inme	# 
+(.*)		\2inme	# others
+
+== ordinal-feminine ==
+
+1		prumire
+
+([-−]?\d+)	$(ordinal-feminine |$1)
+
+(.*o)  	        \1yinme	# zeroyinme
+(.*)onk		\1eninme # -ey-eninme
+(.*(eu|oe))s	\1jhinme # deujhinme, troejhinme
+(.*wat)e	\1rinme	# cwatrinme
+(.*)[es]	\1inme	# 
+(.*)		\1inme	# others
+
+
+== ordinal-number-feminine ==
+
+1	1ire
+
+== ordinal-number(-feminine|-masculine)? ==
+
+1	1î
+(\d+)	\2inme
+
+== help ==
+
+"" $(1), $(2), $(3)\n$(help feminine)$(help masculine)$(help ordinal)$(help ordinal-feminine)$(help ordinal-masculine)$(help ordinal-number-feminine)$(help ordinal-number-masculine)$(help informal)
+(informal) \1: $(\1 1100), $(\1 1200), $(\1 1300)\n
+(feminine|masculine|ordinal(-feminine|-masculine|-number)?) \1: $(\1 1), $(\1 2), $(\1 21)\n

--- a/data/wa.sor
+++ b/data/wa.sor
@@ -33,6 +33,9 @@
 (\d)1 $(\10)-ey-onk
 (\d)(\d) $(\10)-$2
 
+(\d)01 $(\100)-ey-onk
+(\d)001 $(\1000)-ey-onk
+
 1(\d\d) cint[ $1]
 (\d)00$ $1 cints
 (\d)(\d\d) $1 cint[ $2]
@@ -43,11 +46,11 @@
 1(\d{9}) on miyård[ $1]
 (\d{1,3})(\d{9}) $1| miyårds[ $2]
 1(\d{12}) on biyon[ $1]
-(\d{1,3})(\d{12}) $1| biyons[ $2]
+(\d{1,6})(\d{12}) $1| biyons[ $2]
 1(\d{18}) on triyon[ $1]
-(\d{1,3})(\d{18}) $1| triyons[ $2]
+(\d{1,6})(\d{18}) $1| triyons[ $2]
 1(\d{24}) on cwadriyon[-$1]
-(\d{1,3})(\d{24}) $1| cwadriyons[ $2]
+(\d{1,6})(\d{24}) $1| cwadriyons[ $2]
 
 # negative number
 


### PR DESCRIPTION
Data for Walloon language.

currency rules are missing, as I don't understand them,
particularly that it gets complicated for EUR 
("onk" (1 in masculine) becomes "èn" in front of a vowel,
so 1 EUR is "èn euro"; but 0,01 EUR is feminine : "ene cene").

