### PR TITLE
travis-ci: switch to Ubuntu 24.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
+dist: noble
+install: make get-deps
 language: cpp
 script:
     - autoreconf -i
-    - CC=gcc-7 CXX=g++-7 ./configure
+    - ./configure
     - make
     - make -f Makefile.orig check
-addons:
-    apt:
-        sources:
-            - ubuntu-toolchain-r-test
-        packages:
-            - g++-7


### PR DESCRIPTION
Remove references to old g++ versions and switch to a current Ubuntu image instead. Documentation:

* [The Ubuntu 24.04 (Noble Numbat) Build Environment](https://docs.travis-ci.com/user/reference/noble/)
* [Build a C++ Project](https://docs.travis-ci.com/user/languages/cpp/)

Note: I could not test these settings in lieu of a paid TravisCI plan :-(